### PR TITLE
Use astartectl instead of python snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,8 @@ $ make
 Choosing a Device ID
 =========
 
-A 128 bits unique ID should be used, the following snippet could be used to generate it:
+A Base64 url-encoded uuid should be used, you can use [astartectl](https://github.com/astarte-platform/astartectl#installation) to generate one:
 
 ```
-#!/usr/bin/env python3
-import base64
-import uuid
-
-def generate_device_id():
-    device_id_bytes = uuid.uuid4().bytes
-    return base64.urlsafe_b64encode(device_id_bytes).replace(b"=", b"").decode()
-
-print(generate_device_id())
+astartectl utils device-id generate-random
 ```


### PR DESCRIPTION
Replace python snippet with astartectl which is easier to use.