### PR TITLE
Prepare v1.0.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-rc.0] - 2021-05-10
+
 ## [1.0.0-beta.2] - 2021-03-26
 
 ## [1.0.0-beta.1] - 2021-02-16

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get -qq install qt5-default qtbase5-dev libqt5sql5-sql
 WORKDIR /build
 
 # Install Astarte Qt5 SDK
-RUN git clone https://github.com/astarte-platform/astarte-device-sdk-qt5.git -b v1.0.0-beta.2 && \
+RUN git clone https://github.com/astarte-platform/astarte-device-sdk-qt5.git -b v1.0.0-rc.0 && \
 	cd astarte-device-sdk-qt5 && \
 	mkdir build && \
 	cd build && \
@@ -25,7 +25,7 @@ FROM debian:buster-slim
 RUN apt-get update && apt-get -qq install libmosquittopp1 libqt5network5 libqt5sql5-sqlite libssl1.1 ca-certificates
 
 # Add our fresh binaries
-COPY --from=builder /usr/lib/libAstarteDeviceSDKQt5.so.0* /usr/lib/
+COPY --from=builder /usr/lib/libAstarteDeviceSDKQt5.so.1* /usr/lib/
 COPY --from=builder /usr/bin/astarte-validate-interface /usr/bin/
 COPY --from=builder /usr/share/hyperdrive /usr/share/hyperdrive
 COPY --from=builder /build/stream-qt5-test /usr/bin/

--- a/main.cpp
+++ b/main.cpp
@@ -60,19 +60,19 @@ int main(int argc, char *argv[])
             QStringList{QStringLiteral("i"), QStringLiteral("interval")},
             QObject::tr("Interval in ms between two samples."),
             QStringLiteral("interval"),
-            QStringLiteral("100")
+            QStringLiteral("1000")
         },
         {
             QStringList{QStringLiteral("n"), QStringLiteral("interface")},
             QObject::tr("Target interface"),
             QStringLiteral("interface"),
-            QStringLiteral("org.astarteplatform.Values")
+            QStringLiteral("org.astarte-platform.genericsensors.Values")
         },
         {
             QStringList{QStringLiteral("p"), QStringLiteral("path")},
             QObject::tr("Target path."),
             QStringLiteral("path"),
-            QStringLiteral("/realValue")
+            QStringLiteral("/streamTest/value")
         }
     });
 


### PR DESCRIPTION
Update changelog and use astarte-device-sdk-qt5 v1.0.0-rc.0.

Signed-off-by: Davide Bettio <davide.bettio@ispirata.com>