### PR TITLE
Add support for the new naming introduced in the Qt5 SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.0.1] - 2021-12-20
+### Changed
+- Add support for the new naming introduced in the
+  [Qt5 SDK](https://github.com/astarte-platform/astarte-device-sdk-qt5/pull/28).
+- Deprecate `AGENT_KEY` env variable in docker, use `PAIRING_JWT` instead.
+- Deprecate `PAIRING_HOST` env variable in docker, use `PAIRING_URL` instead.
 
 ## [1.0.0] - 2021-06-30
 

--- a/astarte-device-DEVICE_ID_HERE-conf/transport-astarte.conf
+++ b/astarte-device-DEVICE_ID_HERE-conf/transport-astarte.conf
@@ -1,4 +1,5 @@
 [AstarteTransport]
-agentKey=AGENT_KEY_HERE
-endpoint=https://PAIRING_HOST_HERE/v1/REALM_HERE
+pairingJwt=PAIRING_JWT_HERE
+pairingUrl=https://PAIRING_URL_HERE
+realm=REALM_HERE
 persistencyDir=PERSISTENCY_DIR_HERE

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,12 +2,27 @@
 
 set -e
 
+# Support old JWT naming, print warning
+if [[ -v $AGENT_KEY && ! -v $PAIRING_JWT ]]; then
+    echo "AGENT_KEY is deprecated and will be removed in a future release."
+    echo "Start using PAIRING_JWT instead."
+    PAIRING_JWT=$AGENT_KEY
+fi
+
+# Support old PAIRING_HOST, print warning
+if [[ -v $PAIRING_HOST && ! -v $PAIRING_URL ]]; then
+    echo "PAIRING_HOST is deprecated and will be removed in a future release."
+    echo "Start using PAIRING_URL instead."
+    PAIRING_URL=$PAIRING_HOST
+fi
+
 # Configure the device directory
 mkdir astarte-device-$DEVICE_ID-conf
 cat > astarte-device-$DEVICE_ID-conf/transport-astarte.conf <<EOF
 [AstarteTransport]
-agentKey=$AGENT_KEY
-endpoint=$PAIRING_HOST/v1/$REALM
+pairingJwt=$PAIRING_JWT
+pairingUrl=$PAIRING_URL
+realm=$REALM
 persistencyDir=$PERSISTENCY_DIR
 ignoreSslErrors=$IGNORE_SSL_ERRORS
 keepAliveSeconds=$KEEPALIVE


### PR DESCRIPTION
Also adapt docker environment variables to reflect the new naming, while maintaining backwards compatibility