### PR TITLE
Add org.astarte-platform.genericcommands.ServerCommands interface

### DIFF
--- a/interfaces/org.astarte-platform.genericcommands.ServerCommands.json
+++ b/interfaces/org.astarte-platform.genericcommands.ServerCommands.json
@@ -1,0 +1,19 @@
+{
+    "interface_name": "org.astarte-platform.genericcommands.ServerCommands",
+    "version_major": 0,
+    "version_minor": 1,
+    "type": "datastream",
+    "ownership": "server",
+    "description": "Generic server commands interface.",
+    "doc": "This interface allows sending strings representing a command to a device. This allows to build simple applications that interact with the device to, e.g., turn on or off a switch.",
+    "mappings": [
+        {
+            "endpoint": "/command",
+            "type": "string",
+            "explicit_timestamp": true,
+            "database_retention_policy": "use_ttl",
+            "database_retention_ttl": 86400,
+            "doc": "A string representing a command. The command is deleted from Astarte after 24 hours."
+        }
+    ]
+}


### PR DESCRIPTION
This allows to use stream-qt5-test also to show how to send commands to
a device. The code to log what gets received was already in place.

Signed-off-by: Riccardo Binetti <riccardo.binetti@secomind.com>