### PR TITLE
Add server commands to pause/resume/change streaming params

### DIFF
--- a/AstarteStreamQt5Test.cpp
+++ b/AstarteStreamQt5Test.cpp
@@ -22,40 +22,35 @@
 
 #include <HemeraCore/Operation>
 
-#include <QtCore/QDebug>
 #include <QtCore/QDir>
 #include <QtCore/QTimer>
 
-#include <climits>
-#include <math.h>
+#define TELEMETRY_CONFIG_INTERFACE "org.astarte-platform.config.Telemetry"
 
-AstarteStreamQt5Test::AstarteStreamQt5Test(const QByteArray &interface, const QByteArray &path, const QString &function, const QString &device, int interval, double scale, QObject *parent)
+AstarteStreamQt5Test::AstarteStreamQt5Test(const QByteArray &interface, const QByteArray &path,
+    const QString &function, const QString &device, int interval, double scale, QObject *parent)
     : QObject(parent)
     , m_interface(interface)
     , m_path(path)
-    , m_function(function)
-    , m_updateTimer(new QTimer(this))
-    , m_scale(scale)
-    , m_xValue(0)
     , m_ready(false)
 {
-    if (interval >= 0) {
-        m_updateTimer->setInterval(interval);
-    } else {
-        qsrand(QDateTime::currentMSecsSinceEpoch() % UINT_MAX);
-        m_updateTimer->setInterval(randomInterval());
-        m_updateTimer->setSingleShot(true);
-    }
-    connect(m_updateTimer, &QTimer::timeout, this, &AstarteStreamQt5Test::sendValues);
 
-    m_sdk = new AstarteDeviceSDK(QDir::currentPath() + QStringLiteral("/astarte-device-%1-conf/transport-astarte.conf").arg(device), QDir::currentPath() + QStringLiteral("/interfaces"), device.toLatin1());
-    connect(m_sdk->init(), &Hemera::Operation::finished, this, &AstarteStreamQt5Test::checkInitResult);
-    connect(m_sdk, &AstarteDeviceSDK::dataReceived, this, &AstarteStreamQt5Test::handleIncomingData);
+    m_sdk = new AstarteDeviceSDK(QDir::currentPath()
+            + QStringLiteral("/astarte-device-%1-conf/transport-astarte.conf").arg(device),
+        QDir::currentPath() + QStringLiteral("/interfaces"), device.toLatin1());
+    AstarteStreamTelemetry::TelemetryFunction telemetryFunction
+        = AstarteStreamTelemetry::getTelemetryFunction(function.toUtf8());
+    AstarteStreamTelemetry *telemetry
+        = new AstarteStreamTelemetry(m_sdk, interface, path, telemetryFunction, interval, scale);
+    m_telemetries.insert(telemetryFunction, telemetry);
+
+    connect(
+        m_sdk->init(), &Hemera::Operation::finished, this, &AstarteStreamQt5Test::checkInitResult);
+    connect(
+        m_sdk, &AstarteDeviceSDK::dataReceived, this, &AstarteStreamQt5Test::handleIncomingData);
 }
 
-AstarteStreamQt5Test::~AstarteStreamQt5Test()
-{
-}
+AstarteStreamQt5Test::~AstarteStreamQt5Test() {}
 
 void AstarteStreamQt5Test::checkInitResult(Hemera::Operation *op)
 {
@@ -64,54 +59,49 @@ void AstarteStreamQt5Test::checkInitResult(Hemera::Operation *op)
 
     } else {
         m_ready = true;
-        m_updateTimer->start();
+        if (!m_telemetries.isEmpty()) {
+            m_telemetries.first()->start();
+        }
     }
 }
 
-void AstarteStreamQt5Test::sendValues()
+void AstarteStreamQt5Test::handleIncomingData(
+    const QByteArray &interface, const QByteArray &path, const QVariant &value)
 {
-    double x = m_xValue;
-    double value;
+    qDebug() << "Received data, interface: " << interface << "path: " << path
+             << ", value: " << value << ", Qt type name: " << value.typeName();
 
-    if (m_function == QStringLiteral("sin")) {
-        value = sin(x);
-    } else if (m_function == QStringLiteral("noisesin")) {
-        value = sin(x) + ((double) qrand()) / ((double) RAND_MAX) * 0.2;
-    } else if (m_function == QStringLiteral("randomspikessin")) {
-        value = sin(x) + (((double) qrand()) / ((double) RAND_MAX) * 0.1) + ((((double) qrand()) / ((double) RAND_MAX)) > 0.999 ? 100 : 0);
-    } else if (m_function == QStringLiteral("x")) {
-        value = x;
-    } else if (m_function == QStringLiteral("saw")) {
-        value = (fmod(x, 2 * M_PI) - M_PI) / M_PI;
-    } else if (m_function == QStringLiteral("rect")) {
-        value = (fmod(x, 2 * M_PI) - M_PI) > 0 ? 1 : 0;
-    } else if (m_function == QStringLiteral("sinc")) {
-        double t = fmod(x, 10 * 2 * M_PI) - M_PI * 10;
-        value = (t != 0) ? (sin(t) / t) : 1;
-    } else if (m_function == QStringLiteral("random")) {
-        value = ((double) qrand()) / ((double) RAND_MAX);
-    } else {
-        value = (4/M_PI)*sin(x) + (4/3)*M_PI*sin(3*x) + (4/5)*M_PI*sin(5*x) + (4/7)*M_PI*sin(7*x);
+    if (interface.compare(TELEMETRY_CONFIG_INTERFACE) == 0) {
+        QList<QByteArray> paths = path.split('/');
+
+        if (paths.isEmpty() || paths.length() <= 3) {
+            return;
+        }
+
+        QByteArray functionName = paths[2];
+        AstarteStreamTelemetry::TelemetryFunction telemetryFunction
+            = AstarteStreamTelemetry::getTelemetryFunction(functionName);
+
+        AstarteStreamTelemetry *telemetry;
+
+        if (m_telemetries.contains(telemetryFunction)) {
+            telemetry = m_telemetries.value(telemetryFunction);
+        } else {
+            telemetry = new AstarteStreamTelemetry(m_sdk, m_interface, m_path, telemetryFunction);
+            m_telemetries.insert(telemetryFunction, telemetry);
+        }
+
+        QByteArray endpoint = paths[3];
+        if (endpoint.compare("periodMS") == 0) {
+            telemetry->setInterval(value.toInt());
+        } else if (endpoint.compare("scale") == 0) {
+            telemetry->setScale(value.toDouble());
+        }
+
+        if (endpoint.compare("enable") == 0) {
+            telemetry->setEnable(value.toBool());
+        } else {
+            telemetry->restart();
+        }
     }
-
-    qDebug() << x << ": " << QString::number(value, 'f', 5);
-
-    m_sdk->sendData(m_interface, m_path, value, QDateTime::currentDateTime());
-
-    if (m_updateTimer->isSingleShot()) {
-        m_updateTimer->setInterval(randomInterval());
-        m_updateTimer->start();
-    }
-
-    m_xValue += M_PI * 2 * ((double) m_updateTimer->interval()) * m_scale;
-}
-
-void AstarteStreamQt5Test::handleIncomingData(const QByteArray &interface, const QByteArray &path, const QVariant &value)
-{
-    qDebug() << "Received data, interface: " << interface << "path: " << path << ", value: " << value << ", Qt type name: " << value.typeName();
-}
-
-int AstarteStreamQt5Test::randomInterval()
-{
-    return (qrand() % 600) * 1000 + (qrand() % 1000);
 }

--- a/AstarteStreamQt5Test.h
+++ b/AstarteStreamQt5Test.h
@@ -19,6 +19,8 @@
 #ifndef ASTARTESTREAMQT5TEST_H
 #define ASTARTESTREAMQT5TEST_H
 
+#include "AstarteStreamTelemetry.h"
+
 #include <QtCore/QObject>
 
 namespace Hemera {
@@ -39,21 +41,14 @@ public:
 
 private slots:
     void checkInitResult(Hemera::Operation *op);
-    void sendValues();
-
     void handleIncomingData(const QByteArray &interface, const QByteArray &path, const QVariant &value);
 
 private:
     AstarteDeviceSDK *m_sdk;
     QByteArray m_interface;
     QByteArray m_path;
-    QString m_function;
-    QTimer *m_updateTimer;
-    double m_scale;
-    double m_xValue;
     bool m_ready;
-
-    static int randomInterval();
+    QMap<AstarteStreamTelemetry::TelemetryFunction, AstarteStreamTelemetry*> m_telemetries;
 };
 
 #endif

--- a/AstarteStreamTelemetry.cpp
+++ b/AstarteStreamTelemetry.cpp
@@ -1,0 +1,170 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "AstarteStreamTelemetry.h"
+
+#include <QtCore/QDir>
+
+#include <climits>
+#include <cmath>
+
+AstarteStreamTelemetry::AstarteStreamTelemetry(AstarteDeviceSDK *sdk, const QByteArray &interface,
+    const QByteArray &path, TelemetryFunction function, int interval, double scale, QObject *parent)
+    : QObject(parent)
+    , m_sdk(sdk)
+    , m_interface(interface)
+    , m_path(path)
+    , m_function(function)
+    , m_updateTimer(new QTimer(this))
+    , m_scale(scale)
+    , m_xValue(0)
+
+{
+    this->setInterval(interval);
+    connect(m_updateTimer, &QTimer::timeout, this, &AstarteStreamTelemetry::sendValues);
+}
+
+AstarteStreamTelemetry::~AstarteStreamTelemetry() {}
+
+void AstarteStreamTelemetry::start()
+{
+    if (!m_updateTimer->isActive()) {
+        m_updateTimer->start();
+    }
+}
+
+void AstarteStreamTelemetry::restart()
+{
+    if (m_updateTimer->isActive()) {
+        m_updateTimer->stop();
+    }
+
+    m_updateTimer->start();
+}
+
+void AstarteStreamTelemetry::stop()
+{
+    if (m_updateTimer->isActive()) {
+        m_updateTimer->stop();
+    }
+}
+
+void AstarteStreamTelemetry::setInterval(int interval)
+{
+    if (interval > 0) {
+        m_updateTimer->setInterval(interval);
+    } else {
+        qsrand(QDateTime::currentMSecsSinceEpoch() % UINT_MAX);
+        m_updateTimer->setInterval(randomInterval());
+        m_updateTimer->setSingleShot(true);
+    }
+}
+
+void AstarteStreamTelemetry::setScale(double scale)
+{
+    m_scale = scale;
+    this->restart();
+}
+
+void AstarteStreamTelemetry::setEnable(bool enable)
+{
+    if (enable) {
+        this->start();
+    } else {
+        this->stop();
+    }
+}
+
+void AstarteStreamTelemetry::sendValues()
+{
+    double x = m_xValue;
+    double value;
+
+    switch (m_function) {
+        case TelemetryFunction::Default: {
+            value = (4 / M_PI) * sin(x) + (4 / 3) * M_PI * sin(3 * x) + (4 / 5) * M_PI * sin(5 * x)
+                + (4 / 7) * M_PI * sin(7 * x);
+        } break;
+        case TelemetryFunction::Sin: {
+            value = sin(x);
+        } break;
+        case TelemetryFunction::NoiseSin: {
+            value = sin(x) + ((double) qrand()) / ((double) RAND_MAX) * 0.2;
+        } break;
+        case TelemetryFunction::RandomSpikesSin: {
+            value = sin(x) + (((double) qrand()) / ((double) RAND_MAX) * 0.1)
+                + ((((double) qrand()) / ((double) RAND_MAX)) > 0.999 ? 100 : 0);
+        } break;
+        case TelemetryFunction::X: {
+            value = x;
+        } break;
+        case TelemetryFunction::Saw: {
+            value = (fmod(x, 2 * M_PI) - M_PI) / M_PI;
+        } break;
+        case TelemetryFunction::Rect: {
+            value = (fmod(x, 2 * M_PI) - M_PI) > 0 ? 1 : 0;
+        } break;
+        case TelemetryFunction::Sinc: {
+            double t = fmod(x, 10 * 2 * M_PI) - M_PI * 10;
+            value = (t != 0) ? (sin(t) / t) : 1;
+        } break;
+        case TelemetryFunction::Random: {
+            value = ((double) qrand()) / ((double) RAND_MAX);
+        } break;
+    }
+
+    qInfo() <<"functionId: " << m_function <<" " << x << ": " << QString::number(value, 'f', 5);
+
+    m_sdk->sendData(m_interface, m_path, value, QDateTime::currentDateTime());
+
+    if (m_updateTimer->isSingleShot()) {
+        m_updateTimer->setInterval(randomInterval());
+        m_updateTimer->start();
+    }
+
+    m_xValue += M_PI * 2 * ((double) m_updateTimer->interval()) * m_scale;
+}
+
+int AstarteStreamTelemetry::randomInterval()
+{
+    return (qrand() % 600) * 1000 + (qrand() % 1000);
+}
+
+AstarteStreamTelemetry::TelemetryFunction AstarteStreamTelemetry::getTelemetryFunction(
+    const QByteArray &functionName)
+{
+    if (functionName == QStringLiteral("sin")) {
+        return AstarteStreamTelemetry::TelemetryFunction::Sin;
+    } else if (functionName == QStringLiteral("noisesin")) {
+        return AstarteStreamTelemetry::TelemetryFunction::NoiseSin;
+    } else if (functionName == QStringLiteral("randomspikessin")) {
+        return AstarteStreamTelemetry::TelemetryFunction::RandomSpikesSin;
+    } else if (functionName == QStringLiteral("x")) {
+        return AstarteStreamTelemetry::TelemetryFunction::X;
+    } else if (functionName == QStringLiteral("saw")) {
+        return AstarteStreamTelemetry::TelemetryFunction::Saw;
+    } else if (functionName == QStringLiteral("rect")) {
+        return AstarteStreamTelemetry::TelemetryFunction::Rect;
+    } else if (functionName == QStringLiteral("sinc")) {
+        return AstarteStreamTelemetry::TelemetryFunction::Sinc;
+    } else if (functionName == QStringLiteral("random")) {
+        return AstarteStreamTelemetry::TelemetryFunction::Random;
+    } else {
+        return AstarteStreamTelemetry::TelemetryFunction::Default;
+    }
+}

--- a/AstarteStreamTelemetry.h
+++ b/AstarteStreamTelemetry.h
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ASTARTESTREAMTELEMETRY_H
+#define ASTARTESTREAMTELEMETRY_H
+
+#include <AstarteDeviceSDK.h>
+
+#include <QtCore/QObject>
+#include <QtCore/QTimer>
+
+class AstarteStreamTelemetry : public QObject
+{
+    Q_OBJECT
+
+public:
+    enum class TelemetryFunction
+    {
+        Default = 0,
+        Sin = 1,
+        NoiseSin = 2,
+        RandomSpikesSin = 3,
+        X = 4,
+        Saw = 5,
+        Rect = 6,
+        Sinc = 7,
+        Random = 8
+    };
+    Q_ENUM(TelemetryFunction);
+
+    AstarteStreamTelemetry(AstarteDeviceSDK *sdk, const QByteArray &interface,
+        const QByteArray &path, AstarteStreamTelemetry::TelemetryFunction function, int interval = 1000, double scale = 1,
+        QObject *parent = nullptr);
+    ~AstarteStreamTelemetry();
+
+    void start();
+    void stop();
+    void restart();
+    void setInterval(int interval);
+    void setScale(double scale);
+    void setEnable(bool enable);
+
+    static TelemetryFunction getTelemetryFunction(const QByteArray &functionName);
+
+private slots:
+    void sendValues();
+
+private:
+    AstarteDeviceSDK *m_sdk;
+    QByteArray m_interface;
+    QByteArray m_path;
+    TelemetryFunction m_function;
+    QTimer *m_updateTimer;
+    double m_scale;
+    double m_xValue;
+
+    static int randomInterval();
+};
+
+#endif // ASTARTESTREAMTELEMETRY_H

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Add server commands to pause/resume/change streaming params.
+
 ## [1.0.4] - 2022-10-25
 
 ## [1.0.3] - 2022-07-08
@@ -48,7 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.10.2] - 2020-02-14
 ### Changed
-- Use Debian Buster as base image
+- Use Debian Buster as base image.
 
 ## [0.10.1] - 2019-10-02
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,40 @@ Several options are available:
 - `--interface` allows to specify the Astarte interface installed on the device;
 - `--path` allows to specify the mapping endpoint for the interface.
 
+## Configuring the streaming simulator via Astarte Interface
+
+Configuring the streaming options [`function`, `interval`, `scale`] can be accomplished by sending some data from Astarte to the device via `org.astarte-platform.config.Telemetry` interface. This can be done using the Astarte AppEngine API or with astartectl command.
+### `Sin` example:
+
+- Enable the `sin` data generation function, with default period 
+``` shell
+astartectl appengine --appengine-url https://<api url>/appengine    \
+ --token $APPENGINE_TOKEN --realm-name $REALM_NAME                  \ 
+ devices send-data $DEVICE_ID                                       \
+ org.astarte-platform.config.Telemetry                           \
+ --interface-type properties --payload-type boolean                 \
+ /request/sin/enable true  
+```
+
+- Change the `sin` sending interval to 1000ms
+``` shell
+astartectl appengine --appengine-url https://<api url>/appengine    \
+ --token $APPENGINE_TOKEN --realm-name $REALM_NAME                  \ 
+ devices send-data $DEVICE_ID                                       \
+ org.astarte-platform.config.Telemetry                           \
+ --interface-type properties --payload-type integer                 \
+ /request/sin/periodMS 1000  
+```
+
+- Change the `sin` scale to 0.0001
+``` shell
+astartectl appengine --appengine-url https://<api url>/appengine    \
+ --token $APPENGINE_TOKEN --realm-name $REALM_NAME                  \ 
+ devices send-data $DEVICE_ID                                       \
+ org.astarte-platform.config.Telemetry                           \
+ --interface-type properties --payload-type double                 \
+ /request/sin/scale 0.0001
+```
 
 Using the Docker image
 ====

--- a/interfaces/org.astarte-platform.config.Telemetry.json
+++ b/interfaces/org.astarte-platform.config.Telemetry.json
@@ -1,0 +1,24 @@
+{
+    "interface_name": "org.astarte-platform.config.Telemetry",
+    "version_major": 0,
+    "version_minor": 1,
+    "type": "properties",
+    "ownership": "server",
+    "mappings": [
+        {
+            "endpoint": "/request/%{function_name}/enable",
+            "type": "boolean",
+            "description": "Enable/Disable telemetry update."
+        },
+        {
+            "endpoint": "/request/%{function_name}/periodMS",
+            "type": "integer",
+            "description": "Set interval of period milliseconds between the end of the previous update and the start of the next one."
+        },
+        {
+            "endpoint": "/request/%{function_name}/scale",
+            "type": "double",
+            "description": "Set scale factor of function."
+        }
+    ]
+}

--- a/stream-qt5-test.pro
+++ b/stream-qt5-test.pro
@@ -10,6 +10,6 @@ LIBS += -lmosquitto
 LIBS += -lmosquittopp
 LIBS += -lAstarteDeviceSDKQt5
 
-HEADERS += AstarteStreamQt5Test.h
+HEADERS += AstarteStreamQt5Test.h AstarteStreamTelemetry.h
 
-SOURCES += main.cpp AstarteStreamQt5Test.cpp
+SOURCES += main.cpp AstarteStreamQt5Test.cpp AstarteStreamTelemetry.cpp


### PR DESCRIPTION
Implement server commands for supporting pause/resume and change streaming parameters, so the user can pilot streaming simulator with server commands through Astarte.

Close #34.